### PR TITLE
Adding SSM DataProtection provider for hosting on AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,7 @@ Environment variables that must be defined:
 * ServicePassword: The administration password for the REST service (username admin).
 * SendGridAPIKey: The API key for the Sendgrid service
 
-Additional optional environment variables that can be defined when hosting on AWS:
-
-* AWS_REGION: The AWS region used for the cloud storage instance.
-* AWSRoleArn: The AWS role to use to log in to the cloud storage instance.
+Hosting on AWS requires the identity/role used to have policies allowing access to the S3 bucket and SSM Parameter Store.  
 
 ## Deployment
 

--- a/UACloudLibraryServer/AWSFileStorage.cs
+++ b/UACloudLibraryServer/AWSFileStorage.cs
@@ -69,7 +69,6 @@ namespace UACloudLibrary
 
                     _bucket = uri.Bucket;
                     _prefix = uri.Key;
-                 //   if (uri.Region != null) _region = uri.Region;
                 }
                 catch (Exception ex1)
                 {

--- a/UACloudLibraryServer/UA-CloudLibrary.csproj
+++ b/UACloudLibraryServer/UA-CloudLibrary.csproj
@@ -9,7 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.DataProtection.Aws.S3" Version="2.2.0" />
+    <PackageReference Include="Amazon.AspNetCore.DataProtection.SSM" Version="2.1.0" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.1" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.4.9" />
 	<PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.92" />
 	<PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.1" />


### PR DESCRIPTION
Added DataProtection with SSM DataProtected Provider - ParameterStore is a better repo than S3 and the S3 data protection provider is now deprecated.
Changed the AWSFileStorage to use injected singleton S3Client, Replaced all console output to ILogger.  
Close #27 