### PR TITLE
Type-aware response handling in Console Client (no server dependency)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,4 @@ MigrationBackup/
 .ionide/
 /Properties/launchSettings.json
 /SampleConsoleClient/Properties/launchSettings.json
+/UACloudLibraryServer/key-4fe0b423-c5df-420c-b3ae-6065476796ad.xml

--- a/SampleConsoleClient/Program.cs
+++ b/SampleConsoleClient/Program.cs
@@ -32,6 +32,7 @@ namespace SampleConsoleClient
     using GraphQL;
     using GraphQL.Client.Http;
     using GraphQL.Client.Serializer.Newtonsoft;
+    using Newtonsoft.Json;
     using System;
     using System.Collections.Generic;
     using System.Net;
@@ -39,6 +40,7 @@ namespace SampleConsoleClient
     using System.Text.Json;
     using UACloudLibClientLibrary;
     using UACloudLibClientLibrary.Models;
+    using UACloudLibrary.Models;
 
     class Program
     {
@@ -90,7 +92,7 @@ namespace SampleConsoleClient
 
             };
             var response = graphQLClient.SendQueryAsync<UACloudLibGraphQLObjecttypeQueryResponse>(request).GetAwaiter().GetResult();
-            Console.WriteLine(JsonSerializer.Serialize(response, new JsonSerializerOptions { WriteIndented = true }));
+            Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(response, new JsonSerializerOptions { WriteIndented = true }));
 
             Console.WriteLine();
             Console.WriteLine("Testing metadata query");
@@ -106,7 +108,7 @@ namespace SampleConsoleClient
 
             };
             var response2 = graphQLClient.SendQueryAsync<UACloudLibGraphQLMetadataQueryResponse>(request).GetAwaiter().GetResult();
-            Console.WriteLine(JsonSerializer.Serialize(response2, new JsonSerializerOptions { WriteIndented = true }));
+            Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(response2, new JsonSerializerOptions { WriteIndented = true }));
 
             graphQLClient.Dispose();
         }
@@ -128,13 +130,16 @@ namespace SampleConsoleClient
             string[] keywords = { "*" }; // return everything
             string address = webClient.BaseAddress + "infomodel/find";
             webClient.Headers.Add("Content-Type", "application/json");
-            string response = webClient.UploadString(address, "PUT", JsonSerializer.Serialize(keywords));
-            Console.WriteLine(response);
+            var response = webClient.UploadString(address, "PUT", System.Text.Json.JsonSerializer.Serialize(keywords));
+            UANodesetResult[] identifiers = JsonConvert.DeserializeObject<UANodesetResult[]>(response);
+            for (var i = 0; i < identifiers.Length; i++)
+            {
+                Console.WriteLine(JsonConvert.SerializeObject(identifiers[i], Formatting.Indented));
+            }
 
             Console.WriteLine();
             Console.WriteLine("Testing /infomodel/download/{identifier}");
-            string[] identifiers = JsonSerializer.Deserialize<string[]>(response);
-            string identifier = identifiers[0]; // pick the first identifier returned previously
+            string identifier = identifiers[0].Id.ToString(); // pick the first identifier returned previously
             address = webClient.BaseAddress + "infomodel/download/" + Uri.EscapeDataString(identifier);
             response = webClient.DownloadString(address);
             Console.WriteLine(response);

--- a/SampleConsoleClient/Program.cs
+++ b/SampleConsoleClient/Program.cs
@@ -40,7 +40,6 @@ namespace SampleConsoleClient
     using System.Text.Json;
     using UACloudLibClientLibrary;
     using UACloudLibClientLibrary.Models;
-    using UACloudLibrary.Models;
 
     class Program
     {

--- a/SampleConsoleClient/SampleConsoleClient.csproj
+++ b/SampleConsoleClient/SampleConsoleClient.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\UACloudLibraryGraphQLClient\UACloudLibClientLibrary\UACloudLibClientLibrary.csproj" />
+    <ProjectReference Include="..\UACloudLibraryServer\UA-CloudLibrary.csproj" />
   </ItemGroup>
 
 </Project>

--- a/SampleConsoleClient/SampleConsoleClient.csproj
+++ b/SampleConsoleClient/SampleConsoleClient.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\UACloudLibraryGraphQLClient\UACloudLibClientLibrary\UACloudLibClientLibrary.csproj" />
-    <ProjectReference Include="..\UACloudLibraryServer\UA-CloudLibrary.csproj" />
   </ItemGroup>
 
 </Project>

--- a/UACloudLibraryGraphQLClient/UACloudLibClientLibrary/Models/InfoModel.cs
+++ b/UACloudLibraryGraphQLClient/UACloudLibClientLibrary/Models/InfoModel.cs
@@ -15,7 +15,6 @@ namespace UACloudLibClientLibrary
     }
     
  
-
     /// <summary>
     /// Contains the metadata of the nodeset and the nodeset itself
     /// </summary>

--- a/UACloudLibraryGraphQLClient/UACloudLibClientLibrary/Models/UANodesetResult.cs
+++ b/UACloudLibraryGraphQLClient/UACloudLibClientLibrary/Models/UANodesetResult.cs
@@ -1,0 +1,52 @@
+﻿/* ========================================================================
+ * Copyright (c) 2005-2021 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+using Newtonsoft.Json;
+
+namespace UACloudLibClientLibrary
+{
+    /// <summary>
+    /// Defines the structure of a Nodeset Result
+    /// </summary>
+    public class UANodesetResult
+    {
+        [JsonProperty(PropertyName = "nodeset_id")]
+        public uint Id;
+        [JsonProperty(PropertyName = "nodesettitle")]
+        public string Title;
+        [JsonProperty(PropertyName = "orgname")]
+        public string Contributor;
+        [JsonProperty(PropertyName = "license")]
+        public string License;
+        [JsonProperty(PropertyName = "version")]
+        public string Version;
+        [JsonProperty(PropertyName = "adressspacecreationtime")]
+        public System.DateTime ? CreationTime;
+    }
+}

--- a/UACloudLibraryServer/Controllers/InfoModelController.cs
+++ b/UACloudLibraryServer/Controllers/InfoModelController.cs
@@ -63,7 +63,7 @@ namespace UACloudLibrary
 
         [HttpPut]
         [Route("/infomodel/find")]
-        [SwaggerResponse(statusCode: 200, type: typeof(UANodesetResult[]), description: "Discovered OPC UA Information Model identifiers of the models found in the UA Cloud Library matching the keywords provided.")]
+        [SwaggerResponse(statusCode: 200, type: typeof(UANodesetResult[]), description: "Discovered OPC UA Information Model results of the models found in the UA Cloud Library matching the keywords provided.")]
         public IActionResult FindAddressSpaceAsync(
             [FromBody][SwaggerParameter("A list of keywords to search for in the information models. Specify * to return everything.")] string[] keywords)
         {

--- a/UACloudLibraryServer/Models/UANodesetResult.cs
+++ b/UACloudLibraryServer/Models/UANodesetResult.cs
@@ -27,6 +27,8 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+using Newtonsoft.Json;
+
 namespace UACloudLibrary.Models
 {
     /// <summary>
@@ -34,11 +36,17 @@ namespace UACloudLibrary.Models
     /// </summary>
     public class UANodesetResult
     {
-        public uint NodesetResultId;
-        public string NodesetResultTitle;
-        public string NodesetResultOrganization;
-        public string NodesetResultLicense;
-        public string NodesetResultVersion;
-        public System.DateTime ? NodesetResultPublicationDate;
+        [JsonProperty(PropertyName = "nodeset_id")]
+        public uint Id;
+        [JsonProperty(PropertyName = "nodesettitle")]
+        public string Title;
+        [JsonProperty(PropertyName = "orgname")]
+        public string Contributor;
+        [JsonProperty(PropertyName = "license")]
+        public string License;
+        [JsonProperty(PropertyName = "version")]
+        public string Version;
+        [JsonProperty(PropertyName = "adressspacecreationtime")]
+        public System.DateTime ? CreationTime;
     }
 }

--- a/UACloudLibraryServer/PostgreSQLDB.cs
+++ b/UACloudLibraryServer/PostgreSQLDB.cs
@@ -285,14 +285,14 @@ namespace UACloudLibrary
                 if (uint.TryParse(match, out uint matchId))
                 {
                     var thisResult = new UANodesetResult();
-                    thisResult.NodesetResultId = matchId;
-                    thisResult.NodesetResultTitle = RetrieveMetaData(matchId, "nodesettitle") ?? string.Empty;
-                    thisResult.NodesetResultOrganization = RetrieveMetaData(matchId, "orgname") ?? string.Empty;
-                    thisResult.NodesetResultLicense = RetrieveMetaData(matchId, "license") ?? string.Empty;
-                    thisResult.NodesetResultVersion = RetrieveMetaData(matchId, "version") ?? string.Empty;
+                    thisResult.Id = matchId;
+                    thisResult.Title = RetrieveMetaData(matchId, "nodesettitle") ?? string.Empty;
+                    thisResult.Contributor = RetrieveMetaData(matchId, "orgname") ?? string.Empty;
+                    thisResult.License = RetrieveMetaData(matchId, "license") ?? string.Empty;
+                    thisResult.Version = RetrieveMetaData(matchId, "version") ?? string.Empty;
                     var pubDate = RetrieveMetaData(matchId, "nodesetcreationtime");
                     if (DateTime.TryParse(pubDate, out DateTime useDate))
-                        thisResult.NodesetResultPublicationDate = useDate;
+                        thisResult.CreationTime = useDate;
                     nodesetResults.Add(thisResult);
                 }
             }


### PR DESCRIPTION
This commit partially addresses issue https://github.com/OPCFoundation/UA-CloudLibrary/issues/57 by making the Console Client aware of the new complex type response to the REST API find method:

- The UANodesetResult type has been re-factored so members are a closer match the AddressSpace defintion from the InfoModel class.
- JsonProperty decorators have been added to the UANodesetResult to make the REST API response more closely match the GraphQL response.
- Newtonsoft JSON had to be used for the REST interface, because I tried for 4 hours to make System.Text.JSON deserialize its own serialization, while Newtonsoft "just worked." The GraphQL interface code still uses System.Text.JSON but it had to be disambiguated.
- The `find` response must be parsed in order for the next API call to work, since it depends on an Id field in the response
- There is no Server dependency in the Client code, the Type has been re-implemented
- I renamed a class because it was mis-spelled ("Modell" is not a word, "Model" is)