### PR TITLE
Bump Azure.Storage.Blobs from 12.11.0 to 12.13.0 in /UACloudLibraryServer

### DIFF
--- a/UACloudLibraryServer/UA-CloudLibrary.csproj
+++ b/UACloudLibraryServer/UA-CloudLibrary.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="AWSSDK.S3" Version="3.7.8.10" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.130" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.1" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.11.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
         <PackageReference Include="Google.Cloud.Storage.V1" Version="3.7.0" />
         <PackageReference Include="Google.Cloud.AspNetCore.DataProtection.Storage" Version="1.0.0-alpha03" />
   </ItemGroup>    


### PR DESCRIPTION

* fixes CVE-2022-30187